### PR TITLE
fixing inconsistent analytics on node usage

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -462,8 +462,8 @@ func GetNodesUsageHandler(w http.ResponseWriter, req *http.Request) {
 				if property == "cpuCapacity" {
 					usage.CPUCapacity = value.(float64)
 				}
-				if property == "cpuUsage" {
-					usage.CPUUsage = value.(float64)
+				if property == "cpuUsageByPods" {
+					usage.CPUUsageByPods = value.(float64)
 				}
 				if property == "memAllocatable" {
 					usage.MEMAllocatable = value.(float64)
@@ -471,17 +471,11 @@ func GetNodesUsageHandler(w http.ResponseWriter, req *http.Request) {
 				if property == "memCapacity" {
 					usage.MEMCapacity = value.(float64)
 				}
-				if property == "memUsage" {
-					usage.MEMUsage = value.(float64)
-				}
-				if property == "message" {
-					usage.Message = value.(string)
+				if property == "memUsageByPods" {
+					usage.MEMUsageByPods = value.(float64)
 				}
 				if property == "name" {
 					usage.Name = value.(string)
-				}
-				if property == "state" {
-					usage.State = value.(string)
 				}
 			}
 			result = append(result, usage)

--- a/cmd/cluster_consolidated_usage_test.go
+++ b/cmd/cluster_consolidated_usage_test.go
@@ -132,10 +132,8 @@ func TestKOAClusterNodesUsage(t *testing.T) {
 			So(node.Name, ShouldEqual, "gke-cluster-1-default-pool-7f5e6673-lxjd")
 			So(node.CPUCapacity, ShouldEqual, 2)
 			So(node.CPUAllocatable, ShouldEqual, 0.9400000000000001)
-			So(node.CPUUsage, ShouldEqual, 0.098925039)
 			So(node.MEMCapacity, ShouldEqual, 4140904448)
 			So(node.MEMAllocatable, ShouldEqual, 2967547904)
-			So(node.MEMUsage, ShouldEqual, 781180928)
 		})
 	})
 }

--- a/cmd/cluster_usage_db.go
+++ b/cmd/cluster_usage_db.go
@@ -41,14 +41,16 @@ type NamespaceUsageHistory struct {
 type NodeUsage struct {
 	DateUTC string `json:"dateUTC,omitempty"`
 	Name string `json:"name,omitempty"`
-	State string `json:"state,omitempty"`
-	Message string `json:"message,omitempty"`
-	CPUCapacity float64 `json:"cpuCapacity,omitempty"`
+	CPUCapacity    float64 `json:"cpuCapacity,omitempty"`
 	CPUAllocatable float64 `json:"cpuAllocatable,omitempty"`
-	CPUUsage float64 `json:"cpuUsage,omitempty"`
-	MEMCapacity float64 `json:"memCapacity,omitempty"`
+	CPUUsageByPods float64 `json:"cpuUsageByPods,omitempty"`
+	MEMCapacity    float64 `json:"memCapacity,omitempty"`
 	MEMAllocatable float64 `json:"memAllocatable,omitempty"`
-	MEMUsage float64 `json:"memUsage,omitempty"`
+	MEMUsageByPods float64 `json:"memUsageByPods,omitempty"`
+	PodsUsage      []*struct{
+		CPUUsage float64 `json:"cpuUsage,omitempty"`
+		MEMUsage float64 `json:"memUsage,omitempty"`
+	} `json:"podsRunning,omitempty"`
 }
 
 // K8sClusterUsage holds used and non-allocatable memory and CPU resource of a K8s cluster


### PR DESCRIPTION
This PR introduces improvements to fix inconsistent analytics on node usage.
Indeed, after a review of the Kubernetes Metrics API, the cpuUsage and memoryUsage as returned previously are independent from the notion of "non-allocatable" resource.

To be consistent with the notion of non-allocatable resource, the API introduces an notion of "resources used by pods" as shown on the following samples.

Hence : `non-allocatable = capacity - allocatale`  and `available = capacity - non-allocatable - usagebypods`


```
[
  {
    "dateUTC": "2021-04-17T22:48:14",
    "name": "gke-cluster-1-default-pool-7f5e6673-m6so",
    "cpuCapacity": 2,
    "cpuAllocatable": 0.9400000000000001,
    "cpuUsageByPods": 0.057068408,
    "memCapacity": 4130848768,
    "memAllocatable": 2957492224,
    "memUsageByPods": 199458816
  },
  {
    "dateUTC": "2021-04-17T22:48:14",
    "name": "gke-cluster-1-default-pool-7f5e6673-n8d8",
    "cpuCapacity": 2,
    "cpuAllocatable": 0.9400000000000001,
    "cpuUsageByPods": 0.006896725,
    "memCapacity": 4130848768,
    "memAllocatable": 2957492224,
    "memUsageByPods": 96665600
  },
  {
    "dateUTC": "2021-04-17T22:48:14",
    "name": "gke-cluster-1-default-pool-7f5e6673-qxp1",
    "cpuCapacity": 2,
    "cpuAllocatable": 0.9400000000000001,
    "cpuUsageByPods": 0.004305296,
    "memCapacity": 4130848768,
    "memAllocatable": 2957492224,
    "memUsageByPods": 57884672
  },
  {
    "dateUTC": "2021-04-17T22:48:14",
    "name": "gke-cluster-1-default-pool-7f5e6673-5g5l",
    "cpuCapacity": 2,
    "cpuAllocatable": 0.9400000000000001,
    "cpuUsageByPods": 0.005580291,
    "memCapacity": 4130848768,
    "memAllocatable": 2957492224,
    "memUsageByPods": 60694528
  },
  {
    "dateUTC": "2021-04-17T22:48:14",
    "name": "gke-cluster-1-default-pool-7f5e6673-j6cj",
    "cpuCapacity": 2,
    "cpuAllocatable": 0.9400000000000001,
    "cpuUsageByPods": 0.005956893,
    "memCapacity": 4130848768,
    "memAllocatable": 2957492224,
    "memUsageByPods": 61485056
  }
]
```