### PR TITLE
docs: fix status badge broken url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![](krossboard-architecture-thumbnail.png)
 
 ![license](https://img.shields.io/github/license/2-alchemists/krossboard-data-processor.svg?label=License&style=for-the-badge)
-[![lint-test-build](<https://img.shields.io/github/workflow/status/2-alchemists/krossboard-data-processor/lint-test-build?label=lint-test-build&logo=GitHub&style=for-the-badge>)](https://github.com/2-alchemists/krossboard-data-processor/actions/workflows/build.yml)
+[![lint-test-build](<https://img.shields.io/github/actions/workflow/status/2-alchemists/krossboard-data-processor/build.yml?label=lint-test-build&logo=GitHub&style=for-the-badge>)](https://github.com/2-alchemists/krossboard-data-processor/actions/workflows/build.yml)
 
 <!--- 
 ![Build AWS images](https://github.com/2-alchemists/krossboard-data-processor/workflows/build-aws-images/badge.svg)


### PR DESCRIPTION
Fix the Github workflow status badge. See https://github.com/badges/shields/issues/8671 for more.